### PR TITLE
fix character count in validation to account for period

### DIFF
--- a/wizards/common/validation.ts
+++ b/wizards/common/validation.ts
@@ -310,7 +310,7 @@ export function validatePolicyName(value: string, resource: unknown, t?: TFuncti
     const namespace = policy.metadata?.namespace ?? ''
     const combinedNameLength = value.length + namespace.length + 1
 
-    if (combinedNameLength > 64)
+    if (combinedNameLength > 63)
         return t('The combined length of namespace and policy name (namespaceName.policyName) should not exceed 63 characters')
     return undefined
 }


### PR DESCRIPTION
Signed-off-by: rhowingt@redhat.com <rhowingt@redhat.com>

Fix character count validation to account for "." when namespace is appended to policy name.