### PR TITLE
Fix placeholder for WizTextInput

### DIFF
--- a/src/inputs/Input.ts
+++ b/src/inputs/Input.ts
@@ -93,13 +93,6 @@ export function useInputHidden(props: { hidden?: (item: any) => boolean }) {
     return props.hidden ? props.hidden(item) : false
 }
 
-export function lowercaseFirst(label: string) {
-    if (label) {
-        label = label[0].toLowerCase() + label.substr(1)
-    }
-    return label
-}
-
 export function useInput(props: InputCommonProps) {
     const editMode = useEditMode()
     const displayMode = useDisplayMode()
@@ -165,4 +158,27 @@ export function useInput(props: InputCommonProps) {
         hidden,
         disabled,
     }
+}
+
+function lowercaseFirst(label: string) {
+    if (label) {
+        label = label[0].toLowerCase() + label.substring(1)
+    }
+    return label
+}
+
+export function getEnterPlaceholder(props: { label?: string; placeholder?: string }) {
+    return props.placeholder ?? (props.label && props.label.length ? `Enter the ${lowercaseFirst(props.label)}` : '')
+}
+
+export function getSelectPlaceholder(props: { label: string; placeholder?: string }) {
+    return props.placeholder ?? `Select the ${lowercaseFirst(props.label)}`
+}
+
+export function getCollapsedPlaceholder(props: { collapsedPlaceholder?: ReactNode }) {
+    return props.collapsedPlaceholder ?? 'Expand to edit'
+}
+
+export function getAddPlaceholder(props: { placeholder?: string }) {
+    return props.placeholder ?? 'Add'
 }

--- a/src/inputs/WizArrayInput.tsx
+++ b/src/inputs/WizArrayInput.tsx
@@ -24,7 +24,7 @@ import { DisplayMode } from '../contexts/DisplayModeContext'
 import { ItemContext } from '../contexts/ItemContext'
 import { ShowValidationContext } from '../contexts/ShowValidationProvider'
 import { HasValidationErrorContext, ValidationProvider } from '../contexts/ValidationProvider'
-import { InputCommonProps, useInput } from './Input'
+import { getCollapsedPlaceholder, InputCommonProps, useInput } from './Input'
 
 export function wizardArrayItems(props: any, item: any) {
     const id = props.id
@@ -288,15 +288,11 @@ export function ArrayInputItem(props: {
 
     const collapsedContent = useMemo(() => {
         return typeof props.collapsedContent === 'string' ? (
-            <WizTextDetail
-                id={props.collapsedContent}
-                path={props.collapsedContent}
-                placeholder={props.collapsedPlaceholder ?? 'Expand to edit'}
-            />
+            <WizTextDetail id={props.collapsedContent} path={props.collapsedContent} placeholder={getCollapsedPlaceholder(props)} />
         ) : (
             props.collapsedContent
         )
-    }, [props.collapsedContent, props.collapsedPlaceholder])
+    }, [props])
 
     const expandedContent = useMemo(() => {
         if (props.expandedContent) {

--- a/src/inputs/WizAsyncSelect.tsx
+++ b/src/inputs/WizAsyncSelect.tsx
@@ -12,7 +12,7 @@ import { Fragment, ReactNode, useCallback, useEffect, useState } from 'react'
 import { SpinnerButton } from '../components/SpinnerButton'
 import { SyncButton } from '../components/SyncButton'
 import { DisplayMode } from '../contexts/DisplayModeContext'
-import { InputCommonProps, lowercaseFirst, useInput } from './Input'
+import { InputCommonProps, getSelectPlaceholder, useInput } from './Input'
 import './Select.css'
 import { WizFormGroup } from './WizFormGroup'
 
@@ -27,7 +27,7 @@ type WizAsyncSelectProps = InputCommonProps<string> & {
 export function WizAsyncSelect(props: WizAsyncSelectProps) {
     const { asyncCallback } = props
     const { displayMode, value, setValue, validated, hidden, id, disabled } = useInput(props)
-    const placeholder = props.placeholder ?? `Select the ${lowercaseFirst(props.label)}`
+    const placeholder = getSelectPlaceholder(props)
     const [open, setOpen] = useState(false)
     const [options, setOptions] = useState<string[]>([])
     const [loading, setLoading] = useState(false)

--- a/src/inputs/WizKeyValue.tsx
+++ b/src/inputs/WizKeyValue.tsx
@@ -4,7 +4,7 @@ import { Fragment, useState } from 'react'
 import { Indented } from '../components/Indented'
 import { LabelHelp } from '../components/LabelHelp'
 import { DisplayMode } from '../contexts/DisplayModeContext'
-import { InputCommonProps, useInput } from './Input'
+import { getAddPlaceholder, InputCommonProps, useInput } from './Input'
 
 type KeyValueProps = InputCommonProps & { placeholder?: string; summaryList?: boolean }
 
@@ -103,7 +103,7 @@ export function WizKeyValue(props: KeyValueProps) {
             {!Object.keys(pairs).length && <Divider />}
             <div>
                 <Button id="add-button" variant="link" isSmall aria-label="Action" onClick={onNewKey}>
-                    <PlusIcon /> &nbsp; {props.placeholder ?? 'Add'}
+                    <PlusIcon /> &nbsp; {getAddPlaceholder(props)}
                 </Button>
             </div>
         </div>

--- a/src/inputs/WizMultiSelect.tsx
+++ b/src/inputs/WizMultiSelect.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core'
 import { Fragment, ReactNode, useCallback, useMemo, useState } from 'react'
 import { DisplayMode } from '../contexts/DisplayModeContext'
-import { InputCommonProps, lowercaseFirst, useInput } from './Input'
+import { InputCommonProps, getSelectPlaceholder, useInput } from './Input'
 import './Select.css'
 import { WizFormGroup } from './WizFormGroup'
 
@@ -25,7 +25,7 @@ export type WizMultiSelectProps = InputCommonProps<string[]> & {
 
 export function WizMultiSelect(props: WizMultiSelectProps) {
     const { displayMode: mode, value, setValue, validated, hidden, id, disabled } = useInput(props)
-    const placeholder = props.placeholder ?? `Select the ${lowercaseFirst(props.label)}`
+    const placeholder = getSelectPlaceholder(props)
     const [open, setOpen] = useState(false)
 
     const onSelect = useCallback(

--- a/src/inputs/WizNumberInput.tsx
+++ b/src/inputs/WizNumberInput.tsx
@@ -2,7 +2,7 @@ import { NumberInput as PFNumberInput } from '@patternfly/react-core'
 import { Fragment, useCallback } from 'react'
 import { WizTextDetail } from '..'
 import { DisplayMode } from '../contexts/DisplayModeContext'
-import { InputCommonProps, lowercaseFirst, useInput } from './Input'
+import { getEnterPlaceholder, InputCommonProps, useInput } from './Input'
 import { WizFormGroup } from './WizFormGroup'
 
 export type WizNumberInputProps = InputCommonProps<string> & {
@@ -49,7 +49,7 @@ export function WizNumberInput(props: WizNumberInputProps) {
         return <WizTextDetail id={id} path={props.path} label={props.label} />
     }
 
-    const placeholder = props.placeholder ?? `Enter the ${lowercaseFirst(props.label)}`
+    const placeholder = getEnterPlaceholder(props)
 
     return (
         <WizFormGroup {...props} id={id}>

--- a/src/inputs/WizSelect.tsx
+++ b/src/inputs/WizSelect.tsx
@@ -14,7 +14,7 @@ import get from 'get-value'
 import { Fragment, ReactNode, useCallback, useMemo, useState } from 'react'
 import { SpinnerButton } from '../components/SpinnerButton'
 import { DisplayMode } from '../contexts/DisplayModeContext'
-import { InputCommonProps, lowercaseFirst, useInput } from './Input'
+import { InputCommonProps, getSelectPlaceholder, useInput } from './Input'
 import './Select.css'
 import { WizFormGroup } from './WizFormGroup'
 
@@ -60,7 +60,7 @@ type SelectProps<T> = SingleSelectProps<T>
 function SelectBase<T = any>(props: SelectProps<T>) {
     const { displayMode: mode, value, setValue, validated, hidden, id, disabled } = useInput(props)
 
-    const placeholder = props.placeholder ?? `Select the ${lowercaseFirst(props.label)}`
+    const placeholder = getSelectPlaceholder(props)
 
     const keyPath = props.keyPath ?? props.path
 

--- a/src/inputs/WizSingleSelect.tsx
+++ b/src/inputs/WizSingleSelect.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core'
 import { Fragment, ReactNode, useCallback, useEffect, useState } from 'react'
 import { DisplayMode } from '../contexts/DisplayModeContext'
-import { InputCommonProps, lowercaseFirst, useInput } from './Input'
+import { InputCommonProps, getSelectPlaceholder, useInput } from './Input'
 import './Select.css'
 import { WizFormGroup } from './WizFormGroup'
 
@@ -24,7 +24,7 @@ export type WizSingleSelectProps = InputCommonProps<string> & {
 
 export function WizSingleSelect(props: WizSingleSelectProps) {
     const { displayMode: mode, value, setValue, validated, hidden, id, disabled } = useInput(props)
-    const placeholder = props.placeholder ?? `Select the ${lowercaseFirst(props.label)}`
+    const placeholder = getSelectPlaceholder(props)
     const [open, setOpen] = useState(false)
 
     const onSelect = useCallback(

--- a/src/inputs/WizStringsInput.tsx
+++ b/src/inputs/WizStringsInput.tsx
@@ -11,7 +11,7 @@ import { PlusIcon, TrashIcon } from '@patternfly/react-icons'
 import { Fragment } from 'react'
 import { WizTextInput } from '..'
 import { DisplayMode } from '../contexts/DisplayModeContext'
-import { InputCommonProps, useInput } from './Input'
+import { getAddPlaceholder, InputCommonProps, useInput } from './Input'
 import { WizFormGroup } from './WizFormGroup'
 
 export type WizStringsInputProps = InputCommonProps & {
@@ -84,7 +84,7 @@ export function WizStringsInput(props: WizStringsInputProps) {
                 {!values.length && <Divider />}
                 <div>
                     <Button id="add-button" variant="link" isSmall aria-label="Action" onClick={onNewKey}>
-                        <PlusIcon /> &nbsp; {props.placeholder ?? 'Add'}
+                        <PlusIcon /> &nbsp; {getAddPlaceholder(props)}
                     </Button>
                 </div>
             </div>
@@ -170,7 +170,7 @@ export function StringsMapInput(props: StringsMapInputProps) {
                 {!values.length && <Divider />}
                 <div>
                     <Button id="add-button" variant="link" isSmall aria-label="Action" onClick={onNewKey}>
-                        <PlusIcon /> &nbsp; {props.placeholder ?? 'Add'}
+                        <PlusIcon /> &nbsp; {getAddPlaceholder(props)}
                     </Button>
                 </div>
             </div>

--- a/src/inputs/WizTextArea.tsx
+++ b/src/inputs/WizTextArea.tsx
@@ -7,7 +7,7 @@ import { ClearInputButton } from '../components/ClearInputButton'
 import { PasteInputButton } from '../components/PasteInputButton'
 import { ShowSecretsButton } from '../components/ShowSecretsButton'
 import { DisplayMode } from '../contexts/DisplayModeContext'
-import { InputCommonProps, lowercaseFirst, useInput } from './Input'
+import { InputCommonProps, getSelectPlaceholder, useInput } from './Input'
 import { WizFormGroup } from './WizFormGroup'
 
 export type WizTextAreaProps = InputCommonProps<string> & {
@@ -29,7 +29,7 @@ export function WizTextArea(props: WizTextAreaProps) {
         return <WizTextDetail id={id} path={props.path} label={props.label} />
     }
 
-    const placeholder = props.placeholder ?? `Enter the ${lowercaseFirst(props.label)}`
+    const placeholder = getSelectPlaceholder(props)
     const canPaste = props.canPaste !== undefined ? props.canPaste : props.secret === true
 
     return (

--- a/src/inputs/WizTextInput.tsx
+++ b/src/inputs/WizTextInput.tsx
@@ -6,7 +6,7 @@ import { ClearInputButton } from '../components/ClearInputButton'
 import { PasteInputButton } from '../components/PasteInputButton'
 import { ShowSecretsButton } from '../components/ShowSecretsButton'
 import { DisplayMode } from '../contexts/DisplayModeContext'
-import { InputCommonProps, lowercaseFirst, useInput } from './Input'
+import { InputCommonProps, getEnterPlaceholder, useInput } from './Input'
 import { WizFormGroup } from './WizFormGroup'
 
 export type WizTextInputProps = InputCommonProps<string> & {
@@ -26,7 +26,7 @@ export function WizTextInput(props: WizTextInputProps) {
         return <WizTextDetail id={id} path={props.path} label={props.label} />
     }
 
-    const placeholder = props.placeholder ?? props.label !== undefined ? `Enter the ${lowercaseFirst(props.label ?? '')}` : ''
+    const placeholder = getEnterPlaceholder(props)
     const canPaste = props.canPaste !== undefined ? props.canPaste : props.secret === true
 
     if (!props.label) {


### PR DESCRIPTION
Placeholder text was not being used due to an operator precedence error.
![image](https://user-images.githubusercontent.com/42188127/177878106-ccf730e3-d436-43da-8a13-4b92df84ffb2.png)
![image](https://user-images.githubusercontent.com/42188127/177878551-6c64e223-07fa-4c37-9961-599151d618f6.png)

Factored out all the places this pattern was repeated.