### PR TITLE
Fix when `StringsInput` isn't an array

### DIFF
--- a/src/inputs/WizStringsInput.tsx
+++ b/src/inputs/WizStringsInput.tsx
@@ -21,8 +21,7 @@ export type WizStringsInputProps = InputCommonProps & {
 export function WizStringsInput(props: WizStringsInputProps) {
     const { displayMode: mode, value, setValue, id, hidden } = useInput(props)
 
-    let values: string[] = value
-    if (!values) values = []
+    const values: string[] = Array.isArray(value) ? value : []
 
     const onNewKey = () => {
         values.push('')


### PR DESCRIPTION
When an array isn't provided, the UI crashes at `values.map`:
https://github.com/patternfly-labs/react-form-wizard/blob/f67249e6a4e1fc1981d34ed9710986f3f94f3202/src/inputs/WizStringsInput.tsx#L153

Addresses:
- https://github.com/stolostron/backlog/issues/23139