### PR TITLE
Remove `namespaceSelector` from `IamPolicy`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3587,6 +3587,12 @@
                 "negotiator": "0.6.3"
             }
         },
+        "acorn": {
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+            "dev": true
+        },
         "acorn-import-assertions": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
@@ -6392,6 +6398,12 @@
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true
+        },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true
         },
         "execa": {
@@ -11252,20 +11264,6 @@
                 "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.3.1",
                 "webpack-sources": "^3.2.3"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "8.7.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-                    "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-                    "dev": true
-                },
-                "events": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-                    "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-                    "dev": true
-                }
             }
         },
         "webpack-cli": {

--- a/wizards/Policy/stable/AC-Access-Control/policy-limitclusteradmin.yaml
+++ b/wizards/Policy/stable/AC-Access-Control/policy-limitclusteradmin.yaml
@@ -17,9 +17,6 @@ spec:
                   name: policy-limitclusteradmin-example
               spec:
                   severity: medium
-                  namespaceSelector:
-                      include: ['*']
-                      exclude: ['kube-*', 'openshift-*']
                   remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
                   maxClusterRoleBindingUsers: 5
 ---


### PR DESCRIPTION
`IamPolicy` doesn't use the `namespaceSelector`, so removing it will also hide the selectors in the wizard.

Addresses:
- https://github.com/stolostron/backlog/issues/24312