### PR TITLE
Update `MatchExpressions`/`MatchLabels` handling

### DIFF
--- a/src/inputs/WizKeyValue.tsx
+++ b/src/inputs/WizKeyValue.tsx
@@ -1,6 +1,6 @@
 import { Button, Divider, List, ListItem, TextInput } from '@patternfly/react-core'
 import { PlusIcon, TrashIcon } from '@patternfly/react-icons'
-import { Fragment, useState } from 'react'
+import { Fragment } from 'react'
 import { HelperText } from '../components/HelperText'
 import { Indented } from '../components/Indented'
 import { LabelHelp } from '../components/LabelHelp'
@@ -11,7 +11,11 @@ type KeyValueProps = InputCommonProps & { placeholder?: string; summaryList?: bo
 
 export function WizKeyValue(props: KeyValueProps) {
     const { displayMode: mode, value, setValue, hidden, id } = useInput(props)
-    const [pairs] = useState<{ key: string; value: string }[]>(() => Object.keys(value).map((key) => ({ key, value: value[key] })))
+    let pairs = [{ key: '', value: '' }]
+    if (value instanceof Object) {
+        pairs = Object.keys(value).map((key) => ({ key, value: value[key] }))
+    }
+
     const onKeyChange = (index: number, newKey: string) => {
         pairs[index].key = newKey
         setValue(

--- a/wizards/Placement/MatchExpression.tsx
+++ b/wizards/Placement/MatchExpression.tsx
@@ -52,7 +52,7 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
                                 path="values"
                                 isCreatable
                                 required
-                                hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector.operator)}
+                                hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector?.operator)}
                                 options={values}
                             />
                         )
@@ -63,7 +63,7 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
                     label="Values"
                     path="values"
                     required
-                    hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector.operator)}
+                    hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector?.operator)}
                 />
             )}
         </Flex>
@@ -79,7 +79,7 @@ export function MatchExpressionSummary(props: { expression: IExpression }) {
     const { expression } = props
 
     let operator = 'unknown'
-    switch (expression.operator) {
+    switch (expression?.operator) {
         case 'In':
             if (expression.values && expression.values.length > 1) {
                 operator = 'equals any of'
@@ -104,14 +104,14 @@ export function MatchExpressionSummary(props: { expression: IExpression }) {
 
     const displayMode = useDisplayMode()
 
-    if (!expression.key) {
+    if (!expression?.key) {
         if (displayMode === DisplayMode.Details) return <Fragment />
         return <div>Expand to enter expression</div>
     }
 
     return (
         <div>
-            {expression.key} {operator} {expression.values?.map((value) => value).join(', ')}
+            {expression?.key} {operator} {expression?.values?.map((value) => value).join(', ')}
         </div>
     )
 }


### PR DESCRIPTION
- `MatchExpressions` was missing some null/undefined checks and crashing with an empty array. Adding a whole slew of `?` seemed to do it.
- `WizKeyValue` wasn't updating when the YAML updated. This seems to fix it, but I don't know the effect of removing `useState`

Addresses:
- https://github.com/stolostron/backlog/issues/24292