### PR TITLE
Append radio group name to radio ids

### DIFF
--- a/cypress/integration/input.spec.ts
+++ b/cypress/integration/input.spec.ts
@@ -59,7 +59,7 @@ describe('inputs wizard', () => {
         cy.contains('Please fix validation errors')
         cy.get('section #radio-step').within(() => {
             cy.get('#group-5').within(() => {
-                cy.get('#radio-1').click()
+                cy.get('label:contains("Radio 1")').click()
             })
         })
         cy.contains('Next').click()

--- a/src/inputs/WizRadio.tsx
+++ b/src/inputs/WizRadio.tsx
@@ -83,7 +83,7 @@ export function Radio(props: {
     return (
         <Fragment>
             <PfRadio
-                id={props.id}
+                id={radioGroupContext.radioGroup ? props.id + '-' + radioGroupContext.radioGroup : props.id}
                 label={props.label}
                 description={props.description}
                 isChecked={radioGroupContext.value === props.value || (props.value === undefined && !radioGroupContext.value)}


### PR DESCRIPTION
If a wizard had multiple radios with the same id (for example the Policy
Wizard with multiple templates), or potentially if a page had multiple
wizards, then clicking on the label text would change the setting of the
first radio with that id on the page, instead of the input it was likely
supposed to be associated with.

This makes the input's `id` (and the label's `for`) attribute more
unique.

Refs:
 - https://github.com/stolostron/backlog/issues/25009

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>