### PR TITLE
Extend prompt to WizSelect

### DIFF
--- a/src/components/HelperTextPrompt.tsx
+++ b/src/components/HelperTextPrompt.tsx
@@ -1,0 +1,33 @@
+import { Button, Split, SplitItem } from '@patternfly/react-core'
+import { ExternalLinkAltIcon } from '@patternfly/react-icons'
+import { ReactNode } from 'react'
+
+export type HelperTextPromptProps = {
+    helperText?: ReactNode
+    prompt?: { label?: string; href?: string; isDisabled?: boolean }
+}
+
+export function HelperTextPrompt(props: HelperTextPromptProps) {
+    const { helperText, prompt } = props
+    return (
+        <Split>
+            <SplitItem isFilled>
+                <span className="pf-c-form__helper-text">{helperText}</span>
+            </SplitItem>
+            <SplitItem>
+                {prompt?.label && prompt?.href && (
+                    <Button
+                        variant="link"
+                        style={{ paddingRight: '0px' }}
+                        onClick={() => window.open(prompt?.href)}
+                        isDisabled={prompt?.isDisabled}
+                        icon={<ExternalLinkAltIcon />}
+                        iconPosition="right"
+                    >
+                        {prompt?.label}
+                    </Button>
+                )}
+            </SplitItem>
+        </Split>
+    )
+}

--- a/src/inputs/WizSelect.tsx
+++ b/src/inputs/WizSelect.tsx
@@ -17,6 +17,7 @@ import { DisplayMode } from '../contexts/DisplayModeContext'
 import { InputCommonProps, getSelectPlaceholder, useInput } from './Input'
 import './Select.css'
 import { WizFormGroup } from './WizFormGroup'
+import { HelperTextPrompt } from '../components/HelperTextPrompt'
 
 export interface Option<T> {
     id?: string
@@ -44,6 +45,8 @@ type SelectCommonProps<T> = InputCommonProps<T> & {
     keyPath?: string
     isCreatable?: boolean
     onCreate?: (value: string) => void
+    helperText?: string
+    prompt?: { label: string; href: string; isDisabled?: boolean }
 }
 
 interface SingleSelectProps<T> extends SelectCommonProps<T> {
@@ -68,6 +71,7 @@ function SelectBase<T = any>(props: SelectProps<T>) {
 
     const [open, setOpen] = useState(false)
 
+    const { prompt, helperText } = props
     // The drop down items with icons and descriptions - optionally grouped
     const selectOptions:
         | ({
@@ -239,7 +243,7 @@ function SelectBase<T = any>(props: SelectProps<T>) {
     // currently disabling select field when undefined
     return (
         <div id={id}>
-            <WizFormGroup {...props}>
+            <WizFormGroup helperTextNode={HelperTextPrompt({ prompt, helperText })} {...props}>
                 <InputGroup>
                     {!selectOptions && <SpinnerButton />}
                     <PfSelect

--- a/src/inputs/WizSingleSelect.tsx
+++ b/src/inputs/WizSingleSelect.tsx
@@ -1,5 +1,4 @@
 import {
-    Button,
     DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
@@ -8,8 +7,6 @@ import {
     SelectOption,
     SelectOptionObject,
     SelectVariant,
-    Split,
-    SplitItem,
 } from '@patternfly/react-core'
 import { Fragment, ReactNode, useCallback, useEffect, useState } from 'react'
 import { DisplayMode } from '../contexts/DisplayModeContext'

--- a/src/inputs/WizSingleSelect.tsx
+++ b/src/inputs/WizSingleSelect.tsx
@@ -16,7 +16,7 @@ import { DisplayMode } from '../contexts/DisplayModeContext'
 import { InputCommonProps, getSelectPlaceholder, useInput } from './Input'
 import './Select.css'
 import { WizFormGroup } from './WizFormGroup'
-import { ExternalLinkAltIcon } from '@patternfly/react-icons'
+import { HelperTextPrompt } from '../components/HelperTextPrompt'
 
 export type WizSingleSelectProps = InputCommonProps<string> & {
     label: string
@@ -80,31 +80,9 @@ export function WizSingleSelect(props: WizSingleSelectProps) {
         )
     }
 
-    const helperTextPrompt = (
-        <Split>
-            <SplitItem isFilled>
-                <span className="pf-c-form__helper-text">{helperText}</span>
-            </SplitItem>
-            <SplitItem>
-                {prompt?.label && prompt?.href && (
-                    <Button
-                        variant="link"
-                        style={{ paddingRight: '0px' }}
-                        onClick={() => window.open(prompt.href)}
-                        isDisabled={prompt?.isDisabled}
-                        icon={<ExternalLinkAltIcon />}
-                        iconPosition="right"
-                    >
-                        {prompt.label}
-                    </Button>
-                )}
-            </SplitItem>
-        </Split>
-    )
-
     return (
         <div id={id}>
-            <WizFormGroup helperTextNode={helperTextPrompt} {...props} id={id}>
+            <WizFormGroup helperTextNode={HelperTextPrompt({ prompt, helperText })} {...props} id={id}>
                 <InputGroup>
                     <PfSelect
                         isDisabled={disabled || props.readonly}

--- a/wizards/Inputs/InputsWizard.tsx
+++ b/wizards/Inputs/InputsWizard.tsx
@@ -45,6 +45,13 @@ export function InputsWizard() {
                 <Section label="Select">
                     <Select label="Select" path="select.value" options={['Option 1', 'Option 2']} />
                     <Select label="Select required" path="select.required" options={['Option 1', 'Option 2']} required />
+                    <Select
+                        label="Select with prompt"
+                        path="select.value"
+                        options={['Option 1', 'Option 2']}
+                        prompt={{ label: 'See selection', href: '/?route=inputs' }}
+                        required
+                    />
                 </Section>
                 <Section label="MultiSelect">
                     <WizMultiSelect label="MultiSelect" path="multiSelect.value" isCreatable options={['Option 1', 'Option 2']} />


### PR DESCRIPTION
FYI @KevinFCormier @chenz4027  

I made a small error with my last PR, in that I should have extended support for the prompt to the WizSelect component not WizSingleSelect. I've migrated the prompt component to its own module and decided to make it an optional prop for both of the select components. Thanks!

regarding: https://issues.redhat.com/browse/ACM-4740