### PR TITLE
ACM-12807 [v1.29.z] Fix required validation for multi-value inputs

### DIFF
--- a/src/inputs/Input.ts
+++ b/src/inputs/Input.ts
@@ -78,7 +78,7 @@ export function useInputValidation(props: Pick<InputCommonProps, 'id' | 'path' |
     const { required } = useStringContext()
     let error: string | undefined = undefined
     let validated: 'error' | undefined = undefined
-    if (props.required && !value) {
+    if (props.required && (!value || (Array.isArray(value) && value.length === 0))) {
         error = required
     } else if (props.validation) {
         error = props.validation(value, item)

--- a/src/inputs/WizMultiSelect.tsx
+++ b/src/inputs/WizMultiSelect.tsx
@@ -112,7 +112,7 @@ export function WizMultiSelect(props: WizMultiSelectProps) {
                     onToggle={setOpen}
                     selections={selections}
                     onSelect={onSelect}
-                    onClear={props.required ? undefined : onClear}
+                    onClear={onClear}
                     isCreatable={props.isCreatable}
                     validated={validated}
                     onFilter={onFilter}


### PR DESCRIPTION
To test, run locally using `npm start` and navigate to:

- Example Wizards > ArgoCD > Create application set, Step 4. Placement
  - Add **Label expressions** and test **Value** field (for WizMultiSelect)
- Example Wizards > Policy > Create policy, Step 2. Policy templates
  - Under Policy templates, add **Certificate management expiration** template
  - Add **Namespaces match label expressions** and test **Value** field (for WizStringsInput)
- Any other ad hoc testing of inputs 