### PR TITLE
ACM-21051-Error-handing-issue-for-policy-template

### DIFF
--- a/src/Wizard.tsx
+++ b/src/Wizard.tsx
@@ -253,6 +253,10 @@ function MyFooter(props: {
         if (wizardContext.activeStep.name === lastStep.name) {
             // We are on the review step - show validation for all steps
             setShowValidation(true)
+        } else {
+            // if not on review step and there was a submit error
+            // assume user went back and fixed something
+            setSubmitError('')
         }
     }, [lastStep.name, setShowValidation, wizardContext.activeStep.name])
 


### PR DESCRIPTION
reset submit error if user navigates away from review page with the assumption they fixed something

required because we don't want to validate the template step in case the user has pasted the policy straight into the yaml editor